### PR TITLE
AD-HOC feat (*): Create initial Magento files

### DIFF
--- a/modman
+++ b/modman
@@ -1,0 +1,2 @@
+src/app/etc/modules/Sitewards_Webappmanifest.xml app/etc/modules/Sitewards_Webappmanifest.xml
+src/app/code/community/Sitewards/Webappmanifest  app/code/community/Sitewards/Webappmanifest

--- a/src/app/code/community/Sitewards/Webappmanifest/Helper/Data.php
+++ b/src/app/code/community/Sitewards/Webappmanifest/Helper/Data.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Web application manifest implementation for Magento 1.x
+ *
+ * @category  Sitewards
+ * @package   Sitewards_Webappmanifest
+ * @copyright Copyright (c) Sitewards GmbH (http://www.sitewards.com)
+ * @contact   mail@sitewards.com
+ */
+
+/**
+ * This is a concrete implementation of the abstract helper class, so that the system configuration can access the
+ * translation function (__)
+ */
+class Sitewards_Webappmanifest_Helper_Data extends Mage_Core_Helper_Abstract
+{
+}
+

--- a/src/app/code/community/Sitewards/Webappmanifest/etc/config.xml
+++ b/src/app/code/community/Sitewards/Webappmanifest/etc/config.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Web application manifest implementation for Magento 1.x
+
+@category    Sitewards
+@package     Sitewards_Webappmanifest
+@copyright   Copyright (c) Sitewards GmbH (http://www.sitewards.com)
+@contact     mail@sitewards.com
+-->
+<config>
+    <modules>
+        <Sitewards_Webappmanifest>
+            <version>1.0.0</version>
+        </Sitewards_Webappmanifest>
+    </modules>
+    <global>
+        <helpers>
+            <sitewards_webappmanifest>
+                <class>Sitewards_Webappmanifest_Helper</class>
+            </sitewards_webappmanifest>
+        </helpers>
+    </global>
+    <frontend>
+        <layout>
+            <updates>
+                <sitewards_webappmanifest>
+                    <file>sitewards/webappmanifest.xml</file>
+                </sitewards_webappmanifest>
+            </updates>
+        </layout>
+    </frontend>
+    <!-- Todo: Specify the default values for the web app manifest here. At the moment, there are no values, but it
+         will be highly configurable, and storing this XML node here does no harm. -->
+    <default>
+        <sitewards_webappmanifest>
+            <export>
+                <batch_size>100</batch_size>
+            </export>
+        </sitewards_webappmanifest>
+    </default>
+</config>

--- a/src/app/etc/modules/Sitewards_Webappmanifest.xml
+++ b/src/app/etc/modules/Sitewards_Webappmanifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Web application manifest implementation for Magento 1.x
+
+@category    Sitewards
+@package     Sitewards_Webappmanifest
+@copyright   Copyright (c) Sitewards GmbH (http://www.sitewards.com)
+@contact     mail@sitewards.com
+-->
+<config>
+    <modules>
+        <Sitewards_Webappmanifest>
+            <active>true</active>
+            <codePool>community</codePool>
+        </Sitewards_Webappmanifest>
+    </modules>
+</config>


### PR DESCRIPTION
The magento composer installer will fail to install any Magento
extension that is not provided in the expected format. This includes:

1. A modman file
2. Some minimal Magento configuration

This commit adds a minimal set of configuration files to declare a
Magento extension, but does not implement any feature in them.