### PR TITLE
AD-HOC feat (head): Add a reference to the exposed manifest.json endpoint

### DIFF
--- a/app/design/frontend/base/default/layout/sitewards/webappmanifest.xml
+++ b/app/design/frontend/base/default/layout/sitewards/webappmanifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Web application manifest implementation for Magento 1.x
+
+@category    Sitewards
+@package     Sitewards_Webappmanifest
+@copyright   Copyright (c) Sitewards GmbH (http://www.sitewards.com)
+@contact     mail@sitewards.com
+-->
+<layout version="0.1.0">
+    <default>
+        <reference name="head">
+            <action method="addLinkRel">
+                <rel>manifest</rel>
+                <href>/manifest.json</href>
+            </action>
+        </reference>
+    </default>
+</layout>

--- a/modman
+++ b/modman
@@ -1,2 +1,3 @@
-src/app/etc/modules/Sitewards_Webappmanifest.xml app/etc/modules/Sitewards_Webappmanifest.xml
-src/app/code/community/Sitewards/Webappmanifest  app/code/community/Sitewards/Webappmanifest
+src/app/etc/modules/Sitewards_Webappmanifest.xml                     app/etc/modules/Sitewards_Webappmanifest.xml
+src/app/code/community/Sitewards/Webappmanifest                      app/code/community/Sitewards/Webappmanifest
+app/design/frontend/base/default/layout/sitewards/webappmanifest.xml app/design/frontend/base/default/layout/sitewards/webappmanifest.xml


### PR DESCRIPTION
Recent work has established an endpoint at manifest.json that can be
queried for certain offline information. However, at this time, the
browser has no knowledge of this endpoint.

This commit adds a layout file, and reference to this file such that the
`<head>` block will include a reference to the manifest.json.

This has been verified as a reasonable solution, based on the Chrome
LightHouse audit.